### PR TITLE
feat(wrapper): add AutoresetWrapper

### DIFF
--- a/safety_gymnasium/utils/registration.py
+++ b/safety_gymnasium/utils/registration.py
@@ -31,10 +31,10 @@ from gymnasium.envs.registration import (  # pylint: disable=unused-import
 )
 from gymnasium.envs.registration import register as gymnasium_register
 from gymnasium.envs.registration import registry, spec  # pylint: disable=unused-import
-from gymnasium.wrappers import AutoResetWrapper, HumanRendering, OrderEnforcing, RenderCollection
+from gymnasium.wrappers import HumanRendering, OrderEnforcing, RenderCollection
 from gymnasium.wrappers.compatibility import EnvCompatibility
 
-from safety_gymnasium.wrappers import SafePassiveEnvChecker, SafeTimeLimit
+from safety_gymnasium.wrappers import SafeAutoResetWrapper, SafePassiveEnvChecker, SafeTimeLimit
 
 
 safe_registry = set()
@@ -228,7 +228,7 @@ def make(
 
     # Add the autoreset wrapper
     if autoreset:
-        env = AutoResetWrapper(env)
+        env = SafeAutoResetWrapper(env)
 
     # Add human rendering wrapper
     if apply_human_rendering:

--- a/safety_gymnasium/wrappers/__init__.py
+++ b/safety_gymnasium/wrappers/__init__.py
@@ -14,5 +14,6 @@
 # ==============================================================================
 """Env wrappers."""
 
+from safety_gymnasium.wrappers.autoreset import SafeAutoResetWrapper
 from safety_gymnasium.wrappers.env_checker import SafePassiveEnvChecker
 from safety_gymnasium.wrappers.time_limit import SafeTimeLimit

--- a/safety_gymnasium/wrappers/autoreset.py
+++ b/safety_gymnasium/wrappers/autoreset.py
@@ -1,0 +1,70 @@
+# Copyright 2022 Safety Gymnasium Team. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Wrapper for limiting the time steps of an environment."""
+
+from gymnasium.wrappers.autoreset import AutoResetWrapper
+
+
+class SafeAutoResetWrapper(AutoResetWrapper):
+    """A class for providing an automatic reset functionality for gymnasium environments when calling :meth:`self.step`.
+
+    When calling step causes :meth:`Env.step` to return `terminated=True` or `truncated=True`,
+    :meth:`Env.reset` is called, and the return format of :meth:`self.step` is as follows:
+    ``(new_obs, final_reward, final_terminated, final_truncated, info)``
+    with new step API and ``(new_obs, final_reward, final_done, info)`` with the old step API.
+
+     - ``new_obs`` is the first observation after calling :meth:`self.env.reset`
+     - ``final_reward`` is the reward after calling :meth:`self.env.step`, prior to calling :meth:`self.env.reset`.
+     - ``final_terminated`` is the terminated value before calling :meth:`self.env.reset`.
+     - ``final_truncated`` is the truncated value before calling :meth:`self.env.reset`. Both `final_terminated`
+        and `final_truncated` cannot be False.
+     - ``info`` is a dict containing all the keys from the info dict returned by the call to :meth:`self.env.reset`,
+       with an additional key "final_observation" containing the observation returned by the last call to
+       :meth:`self.env.step` and "final_info" containing the info dict returned by the last call to
+       :meth:`self.env.step`.
+
+    Warning: When using this wrapper to collect roll outs, note that when :meth:`Env.step` returns
+        `terminated` or `truncated`, a new observation from after calling :meth:`Env.reset`
+        is returned by :meth:`Env.step` alongside the final reward, terminated and truncated state
+        from the previous episode. If you need the final state from the previous episode, you need
+        to retrieve it via the "final_observation" key in the info dict.
+        Make sure you know what you're doing if you use this wrapper!
+    """
+
+    def step(self, action):
+        """Steps through the environment with action and resets the environment if a terminated or
+            truncated signal is encountered.
+
+        Args:
+            action: The action to take
+
+        Returns:
+            The autoreset environment :meth:`step`
+        """
+        obs, reward, cost, terminated, truncated, info = self.env.step(action)
+        if terminated or truncated:
+            new_obs, new_info = self.env.reset()
+            assert (
+                'final_observation' not in new_info
+            ), 'info dict cannot contain key "final_observation" '
+            assert 'final_info' not in new_info, 'info dict cannot contain key "final_info" '
+
+            new_info['final_observation'] = obs
+            new_info['final_info'] = info
+
+            obs = new_obs
+            info = new_info
+
+        return obs, reward, cost, terminated, truncated, info

--- a/safety_gymnasium/wrappers/autoreset.py
+++ b/safety_gymnasium/wrappers/autoreset.py
@@ -18,41 +18,30 @@ from gymnasium.wrappers.autoreset import AutoResetWrapper
 
 
 class SafeAutoResetWrapper(AutoResetWrapper):
-    """A class for providing an automatic reset functionality for gymnasium environments when calling :meth:`self.step`.
+    """A class for providing an automatic reset functionality for gymnasium environments when calling :meth:`step`.
 
-    When calling step causes :meth:`Env.step` to return `terminated=True` or `truncated=True`,
-    :meth:`Env.reset` is called, and the return format of :meth:`self.step` is as follows:
-    ``(new_obs, final_reward, final_terminated, final_truncated, info)``
-    with new step API and ``(new_obs, final_reward, final_done, info)`` with the old step API.
+     - ``new_obs`` is the first observation after calling ``self.env.reset()``
+     - ``final_reward`` is the reward after calling ``self.env.step()``, prior to calling ``self.env.reset()``.
+     - ``final_terminated`` is the terminated value before calling ``self.env.reset()``.
+     - ``final_truncated`` is the truncated value before calling ``self.env.reset()``. Both ``final_terminated`` and ``final_truncated`` cannot be False.
+     - ``info`` is a dict containing all the keys from the info dict returned by the call to ``self.env.reset()``,
+       with an additional key "final_observation" containing the observation returned by the last call to ``self.env.step()``
+       and "final_info" containing the info dict returned by the last call to ``self.env.step()``.
 
-     - ``new_obs`` is the first observation after calling :meth:`self.env.reset`
-     - ``final_reward`` is the reward after calling :meth:`self.env.step`, prior to calling :meth:`self.env.reset`.
-     - ``final_terminated`` is the terminated value before calling :meth:`self.env.reset`.
-     - ``final_truncated`` is the truncated value before calling :meth:`self.env.reset`. Both `final_terminated`
-        and `final_truncated` cannot be False.
-     - ``info`` is a dict containing all the keys from the info dict returned by the call to :meth:`self.env.reset`,
-       with an additional key "final_observation" containing the observation returned by the last call to
-       :meth:`self.env.step` and "final_info" containing the info dict returned by the last call to
-       :meth:`self.env.step`.
-
-    Warning: When using this wrapper to collect roll outs, note that when :meth:`Env.step` returns
-        `terminated` or `truncated`, a new observation from after calling :meth:`Env.reset`
-        is returned by :meth:`Env.step` alongside the final reward, terminated and truncated state
-        from the previous episode. If you need the final state from the previous episode, you need
-        to retrieve it via the "final_observation" key in the info dict.
+    Warning: When using this wrapper to collect roll-outs, note that when :meth:`Env.step` returns ``terminated`` or ``truncated``, a
+        new observation from after calling :meth:`Env.reset` is returned by :meth:`Env.step` alongside the
+        final reward, terminated and truncated state from the previous episode.
+        If you need the final state from the previous episode, you need to retrieve it via the
+        "final_observation" key in the info dict.
         Make sure you know what you're doing if you use this wrapper!
-    """
+    """  # pylint: disable=line-too-long
 
     def step(self, action):
-        """Steps through the environment with action and resets the environment if a terminated or
-            truncated signal is encountered.
+        """A class for providing an automatic reset functionality for gymnasium environments when calling :meth:`step`.
 
         Args:
-            action: The action to take
-
-        Returns:
-            The autoreset environment :meth:`step`
-        """
+            env (gym.Env): The environment to apply the wrapper
+        """  # pylint: disable=line-too-long
         obs, reward, cost, terminated, truncated, info = self.env.step(action)
         if terminated or truncated:
             new_obs, new_info = self.env.reset()


### PR DESCRIPTION
## Description

refer #22, when the user uses autorest by passing argument `autoreset = True` in the make function, safety_gymnaisum uses AutoresetWrapper in the gymnasium which doesn't have cost.

## Motivation and Context

close #22 

- [x] I have raised an issue to propose this change ([required](https://github.com/PKU-MARL/safety-gymnasium/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/PKU-MARL/safety-gymnasium/blob/main/CONTRIBUTING.md) guide. (**required**)
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format`. (**required**)
- [x] I have checked the code using `make lint`. (**required**)
- [x] I have ensured `make test` pass. (**required**)
